### PR TITLE
css fix to prevent layout breaking

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -21,7 +21,7 @@ body {
 }
 
 /*
-  Fixes <pre> <code> layout breaking in Firefox 
+  Fixes <pre> <code> layout breaking 
 */
 pre {
   white-space: pre-wrap;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -19,3 +19,12 @@ body {
   background: var(--background);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+/*
+  Fixes <pre> <code> layout breaking in Firefox 
+*/
+pre {
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  overflow-x: auto;
+}


### PR DESCRIPTION
```<pre><code></code></pre>``` elements breaks the flex layout see below

![image](https://github.com/user-attachments/assets/ffc7a3b5-8c29-4ede-982e-536424ce14f8)

To fix this issue I added to the global css files a few lines of code to the pre element which fixes the issue

![image](https://github.com/user-attachments/assets/c189766d-ebc0-40eb-888b-984b63a4de0a)
